### PR TITLE
Feature/uc13 show customer per product

### DIFF
--- a/Grocery.App/ViewModels/BoughtProductsViewModel.cs
+++ b/Grocery.App/ViewModels/BoughtProductsViewModel.cs
@@ -24,7 +24,15 @@ namespace Grocery.App.ViewModels
 
         partial void OnSelectedProductChanged(Product? oldValue, Product newValue)
         {
-            //Zorg dat de lijst BoughtProductsList met de gegevens die passen bij het geselecteerde product. 
+            // Start with a clear list
+            BoughtProductsList.Clear();
+
+            foreach (BoughtProducts boughtProduct in _boughtProductsService.Get(newValue.Id))
+            {
+                BoughtProductsList.Add(boughtProduct);
+            }
+            
+            // Zorg dat de lijst BoughtProductsList met de gegevens die passen bij het geselecteerde product. 
         }
 
         [RelayCommand]

--- a/Grocery.App/ViewModels/GroceryListViewModel.cs
+++ b/Grocery.App/ViewModels/GroceryListViewModel.cs
@@ -10,13 +10,21 @@ namespace Grocery.App.ViewModels
     {
         public ObservableCollection<GroceryList> GroceryLists { get; set; }
         private readonly IGroceryListService _groceryListService;
+        private readonly GlobalViewModel _globalViewModel;
+        
 
-        public GroceryListViewModel(IGroceryListService groceryListService) 
+        [ObservableProperty] private string nameOfClient = string.Empty;
+        
+        public GroceryListViewModel(IGroceryListService groceryListService, GlobalViewModel globalViewModel) 
         {
             Title = "Boodschappenlijst";
             _groceryListService = groceryListService;
             GroceryLists = new(_groceryListService.GetAll());
+            _globalViewModel = globalViewModel;
+            nameOfClient = _globalViewModel.Client.Name;
         }
+        
+        
 
         [RelayCommand]
         public async Task SelectGroceryList(GroceryList groceryList)
@@ -34,6 +42,17 @@ namespace Grocery.App.ViewModels
         {
             base.OnDisappearing();
             GroceryLists.Clear();
+        }
+
+        [RelayCommand]
+        public async Task ShowBoughtProducts()
+        {
+            // Check if the user has a admin role
+            if (_globalViewModel.Client.Metb == Role.Admin)
+            {
+                await Shell.Current.GoToAsync(nameof(Views.BoughtProductsView));
+            }
+            
         }
     }
 }

--- a/Grocery.App/Views/BoughtProductsView.xaml
+++ b/Grocery.App/Views/BoughtProductsView.xaml
@@ -6,6 +6,13 @@
              x:Class="Grocery.App.Views.BoughtProductsView"
              x:DataType="vm:BoughtProductsViewModel"
              Title="BoughtProductsView">
+    
+    <Shell.TitleView>
+        <Grid>
+            <Label Text="Bought product" FontSize="Large" HorizontalOptions="Center" VerticalOptions="Center" />
+        </Grid>
+    </Shell.TitleView>
+    
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="4*"/>
@@ -17,6 +24,7 @@
         </Grid.RowDefinitions>
         <Picker Grid.Column="0" Grid.Row="0" Margin="10,0,0,0" Title="Klik op onderstaand pijltje om een product te selecteren:"
         ItemsSource="{Binding Products}"
+        ItemDisplayBinding="{Binding Name}"
         SelectedItem="{Binding SelectedProduct, Mode=TwoWay}" 
         SelectedIndexChanged="Picker_SelectedIndexChanged"
         BackgroundColor="{StaticResource Primary}"
@@ -35,6 +43,8 @@
                                 <ColumnDefinition Width="*"/>
                             </Grid.ColumnDefinitions>
                             <!-- Toon hier de naam van de Client naam van de boodschappenlijst -->
+                            <Label Grid.Column="0" Text="{Binding Client.Name}"/>
+                            <Label Grid.Column="1" Text="{Binding GroceryList.Name}"/>
                         </Grid>
                     </DataTemplate>
                 </CollectionView.ItemTemplate>

--- a/Grocery.App/Views/GroceryListsView.xaml
+++ b/Grocery.App/Views/GroceryListsView.xaml
@@ -11,6 +11,10 @@
             <Label Text="Boodschappenlijsten" FontSize="Large" HorizontalOptions="Center" VerticalOptions="Center" />
         </Grid>
     </Shell.TitleView>
+    
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="{Binding NameOfClient}" Command="{Binding ShowBoughtProductsCommand}"/>
+    </ContentPage.ToolbarItems>
 
     <Border Stroke="#C49B33"
         StrokeThickness="4"

--- a/Grocery.Core.Data/Repositories/ClientRepository.cs
+++ b/Grocery.Core.Data/Repositories/ClientRepository.cs
@@ -13,7 +13,7 @@ namespace Grocery.Core.Data.Repositories
             clientList = [
                 new Client(1, "M.J. Curie", "user1@mail.com", "IunRhDKa+fWo8+4/Qfj7Pg==.kDxZnUQHCZun6gLIE6d9oeULLRIuRmxmH2QKJv2IM08="),
                 new Client(2, "H.H. Hermans", "user2@mail.com", "dOk+X+wt+MA9uIniRGKDFg==.QLvy72hdG8nWj1FyL75KoKeu4DUgu5B/HAHqTD2UFLU="),
-                new Client(3, "A.J. Kwak", "user3@mail.com", "sxnIcZdYt8wC8MYWcQVQjQ==.FKd5Z/jwxPv3a63lX+uvQ0+P7EuNYZybvkmdhbnkIHA=")
+                new Client(3, "A.J. Kwak", "user3@mail.com", "sxnIcZdYt8wC8MYWcQVQjQ==.FKd5Z/jwxPv3a63lX+uvQ0+P7EuNYZybvkmdhbnkIHA=", Role.Admin)
             ];
         }
 

--- a/Grocery.Core/Interfaces/Services/IBoughtProductsService.cs
+++ b/Grocery.Core/Interfaces/Services/IBoughtProductsService.cs
@@ -5,6 +5,6 @@ namespace Grocery.Core.Interfaces.Services
 {
     public interface IBoughtProductsService
     {
-        public List<BoughtProducts> Get(int? productId);
+        public List<BoughtProducts> Get(int productId);
     }
 }

--- a/Grocery.Core/Models/Client.cs
+++ b/Grocery.Core/Models/Client.cs
@@ -1,14 +1,22 @@
-﻿
+﻿[Flags]
+public enum Role
+{
+    None = 0,
+    Admin = 1
+}
+
 namespace Grocery.Core.Models
 {
     public partial class Client : Model
     {
         public string EmailAddress { get; set; }
         public string Password { get; set; }
-        public Client(int id, string name, string emailAddress, string password) : base(id, name)
+        public Role Metb;
+        public Client(int id, string name, string emailAddress, string password, Role metb = Role.None) : base(id, name)
         {
             EmailAddress=emailAddress;
             Password=password;
+            Metb = metb;
         }
     }
 }

--- a/Grocery.Core/Services/BoughtProductsService.cs
+++ b/Grocery.Core/Services/BoughtProductsService.cs
@@ -11,6 +11,7 @@ namespace Grocery.Core.Services
         private readonly IClientRepository _clientRepository;
         private readonly IProductRepository _productRepository;
         private readonly IGroceryListRepository _groceryListRepository;
+        
         public BoughtProductsService(IGroceryListItemsRepository groceryListItemsRepository, IGroceryListRepository groceryListRepository, IClientRepository clientRepository, IProductRepository productRepository)
         {
             _groceryListItemsRepository=groceryListItemsRepository;
@@ -18,9 +19,60 @@ namespace Grocery.Core.Services
             _clientRepository=clientRepository;
             _productRepository=productRepository;
         }
-        public List<BoughtProducts> Get(int? productId)
+
+        private List<GroceryListItem> GetGroceryListItemsByProductId(int productId)
         {
-            throw new NotImplementedException();
+            return _groceryListItemsRepository
+                .GetAll()
+                .Where(groceryListItem => groceryListItem.ProductId == productId)
+                .ToList();
         }
+        
+        private BoughtProducts? CreateBoughtProduct(GroceryListItem groceryListItem, Product product)
+        {
+            GroceryList? groceryList = _groceryListRepository.Get(groceryListItem.GroceryListId);
+            if (groceryList == null) return null;
+
+            Client? client = _clientRepository.Get(groceryList.ClientId);
+            if (client == null) return null;
+
+            return new BoughtProducts(client, groceryList, product);
+        }
+
+        public List<BoughtProducts> Get(int productId)
+        {
+            Product? product = _productRepository.Get(productId);
+            if (product == null) return [];
+            
+            List<GroceryListItem> groceryListItems = GetGroceryListItemsByProductId(productId);
+            
+            List<BoughtProducts> boughtProducts = groceryListItems
+                .Select(groceryListItem => CreateBoughtProduct(groceryListItem, product))
+                .OfType<BoughtProducts>()
+                .ToList();
+            
+            return boughtProducts;
+        }
+        
+        
+        
+        // public List<BoughtProducts> Get2(int productId)
+        // {
+        //     Product? product = _productRepository.Get(productId);
+        //     if (product == null) return [_boughtProductsList];
+        //     
+        //     List<GroceryListItem> groceryListItemRepository = _groceryListItemsRepository.GetAll().Where(glir => glir.ProductId == productId).ToList();
+        //     foreach (GroceryListItem glirItem in groceryListItemRepository)
+        //     {
+        //         // Get GroceryList
+        //         GroceryList groceryList = _groceryListRepository.Get(glirItem.GroceryListId);
+        //         if (groceryList == null) break;
+        //         // Get client
+        //         Client client = _clientRepository.Get(groceryList.ClientId);
+        //         if (client == null) break;
+        //         _boughtProductsList.Add(new BoughtProducts(client, groceryList, product));
+        //     }
+        //     return _boughtProductsList;
+        // }
     }
 }


### PR DESCRIPTION
# UC13 show customer/grocerylist per product
This feature gives the admin the ability to see which user (client) grocery combination has a specific product.

## Changes included
- Client
  - Added a `Role` enum to the client with the options:
    - `None`
    - `Admin`
- view
  - Added a link in the grocery view to navigate to the _Bought Products page._
  - Added a table on the _Bought Products page_ to display results.
page
  - Added the table in the boughtproducts page
- Get boughtproducts
  - added three method to get the information of the boughtproducts
    - `GetGroceryListItemsByProductId()`
    - `CreateBoughtProduct()`
    - `Get()`


## Summary
An admin can now easily see, on what grocery list each products stand.